### PR TITLE
Add auth (register + JWT) and ticket booking in orders

### DIFF
--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -1,0 +1,22 @@
+from django.contrib.auth import get_user_model
+from django.contrib.auth.password_validation import validate_password
+from rest_framework import serializers
+
+User = get_user_model()
+
+
+class UserRegisterSerializer(serializers.ModelSerializer):
+    password = serializers.CharField(write_only=True, validators=[validate_password])
+
+    class Meta:
+        model = User
+        fields = ("id", "username", "email", "password")
+
+    def create(self, validated_data):
+        user = User(
+            username=validated_data["username"],
+            email=validated_data.get("email", ""),
+        )
+        user.set_password(validated_data["password"])
+        user.save()
+        return user

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,3 +1,10 @@
 from django.urls import path
+from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
-urlpatterns = []
+from accounts.views import RegisterView
+
+urlpatterns = [
+    path("register/", RegisterView.as_view(), name="register"),
+    path("token/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
+    path("token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
+]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,0 +1,9 @@
+from rest_framework import generics
+from rest_framework.permissions import AllowAny
+
+from accounts.serializers import UserRegisterSerializer
+
+
+class RegisterView(generics.CreateAPIView):
+    serializer_class = UserRegisterSerializer
+    permission_classes = (AllowAny,)

--- a/airport/services.py
+++ b/airport/services.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+from django.db import IntegrityError, transaction
+from django.core.exceptions import ValidationError as DjangoValidationError
+
+from airport.models import Order, Ticket, Flight
+
+
+class SeatBookingError(Exception):
+    """Raised when booking seats fails due to validation or conflicts."""
+
+
+@transaction.atomic
+def create_order_with_tickets(*, user, flight: Flight, seats: Iterable[dict]) -> Order:
+    """
+    Creates an order and books seats (tickets) for a given flight.
+
+    seats: iterable of {"row": int, "seat": int}
+
+    Validations:
+    - no duplicates in request
+    - bounds: 1..rows and 1..seats_in_row
+    - already taken seats are not allowed
+    - atomic transaction
+    """
+    requested = []
+    for s in seats:
+        try:
+            row = int(s["row"])
+            seat = int(s["seat"])
+        except (KeyError, TypeError, ValueError) as e:
+            raise SeatBookingError("Each seat must contain integer 'row' and 'seat'.") from e
+        requested.append((row, seat))
+
+    if not requested:
+        raise SeatBookingError("Seats list cannot be empty.")
+
+    # duplicates in request
+    requested_set = set(requested)
+    if len(requested_set) != len(requested):
+        raise SeatBookingError("Duplicate seats in request.")
+
+    airplane = flight.airplane
+
+    # bounds check
+    for row, seat in requested_set:
+        if not (1 <= row <= airplane.rows):
+            raise SeatBookingError(f"Row {row} is out of range for airplane {airplane.name}.")
+        if not (1 <= seat <= airplane.seats_in_row):
+            raise SeatBookingError(f"Seat {seat} is out of range for airplane {airplane.name}.")
+
+    # check already taken seats (single query + set intersection)
+    rows = [r for r, _ in requested_set]
+    existing = set(
+        Ticket.objects.filter(flight=flight, row__in=rows).values_list("row", "seat")
+    )
+    taken = requested_set.intersection(existing)
+    if taken:
+        taken_sorted = sorted(taken)
+        raise SeatBookingError(f"Some seats are already taken: {taken_sorted}")
+
+    order = Order.objects.create(user=user)
+
+    tickets = []
+    for row, seat in requested_set:
+        ticket = Ticket(
+            flight=flight,
+            order=order,
+            row=row,
+            seat=seat,
+        )
+        # Ticket.clean() checks bounds using flight.airplane (extra safety)
+        try:
+            ticket.full_clean()
+        except DjangoValidationError as e:
+            raise SeatBookingError(str(e.message_dict)) from e
+        tickets.append(ticket)
+
+    try:
+        Ticket.objects.bulk_create(tickets)
+    except IntegrityError as e:
+        # DB unique constraint fallback (race condition safety)
+        raise SeatBookingError("One or more seats are already taken.") from e
+
+    return order

--- a/airport/views.py
+++ b/airport/views.py
@@ -14,6 +14,7 @@ from airport.serializers import (
     FlightListSerializer,
     FlightDetailSerializer,
     OrderSerializer,
+    OrderCreateSerializer,
 )
 
 
@@ -101,19 +102,12 @@ class FlightViewSet(viewsets.ModelViewSet):
 
 
 class OrderViewSet(viewsets.ModelViewSet):
-    """
-    For now:
-    - users can list their own orders
-    - create empty order (tickets logic will be implemented in PR #4)
-    """
-    serializer_class = OrderSerializer
     permission_classes = (IsAuthenticated,)
 
     def get_queryset(self):
-        return (
-            Order.objects.filter(user=self.request.user)
-            .prefetch_related("tickets__flight")
-        )
+        return Order.objects.filter(user=self.request.user).prefetch_related("tickets__flight")
 
-    def perform_create(self, serializer):
-        serializer.save(user=self.request.user)
+    def get_serializer_class(self):
+        if self.action == "create":
+            return OrderCreateSerializer
+        return OrderSerializer


### PR DESCRIPTION
Added user registration endpoint

Added JWT obtain/refresh endpoints (SimpleJWT)

Implemented order creation with seat booking:

validates seat bounds based on airplane rows/seats_in_row

prevents duplicates in request

prevents booking already taken seats

atomic transaction for order + tickets

Users can list/create only their own orders (existing behavior preserved)